### PR TITLE
Fix for target name floating after UnitPanel hiding

### DIFF
--- a/MUI_Core/Modules/BottomUI/UnitPanels/UnitNames.lua
+++ b/MUI_Core/Modules/BottomUI/UnitPanels/UnitNames.lua
@@ -126,7 +126,7 @@ function C_UnitPanels:SetUpUnitNames(data)
       UpdateUnitNameText(data, "player");
     end);
 
-  em:CreateEventHandlerWithKey("PLAYER_TARGET_CHANGED", "MuiUnitNames_TargetChanged",
+  em:CreateEventHandlerWithKey("PLAYER_TARGET_CHANGED, PLAYER_ENTERING_WORLD", "MuiUnitNames_TargetChanged",
     function()
       if (UnitExists("target")) then
         UpdateUnitNameText(data, "target");


### PR DESCRIPTION
Fix for #145. The UnitPanels don't use :Hide() to hide the frames, instead the alpha is changed on the textures. When no target is selected, the text gets set to an empty string. The problem here is: when teleporting (between the events "PLAYER_LEAVING_WORLD" and "PLAYER_ENTERING_WORLD") the target changed event won't trigger. This commit adds "PLAYER_ENTERING_WORLD" to the unitname's eventhandler.